### PR TITLE
reuse Facebook app ID and add variable for Facebook client token

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,15 +22,14 @@ In order to run the sample app you will need to install some required software, 
 - Java Runtime AutoUpgrader;
 - Adopt OpenJDK 8.
 
-## Add your app id
+## Add your app ID and client token
 
-In order to run the app, you will need to update the code and add your Facebook Developer App Id. If you don't have an app, check out this [link](https://developers.facebook.com/docs/development/).
+In order to run the app, you will need to update the code and add your Facebook Developer App ID and Client Token. If you don't have an app, check out this [link](https://developers.facebook.com/docs/development/).
 
-Update the following files:
-- MainActivity.java
+Update the following file(s):
 - strings.xml
 
-You will need to fill in your app id in the `"YOUR_APP_ID"` strings.
+You will need to replace `YOUR_APP_ID` with your app's ID and `YOUR_CLIENT_TOKEN` with your app's client token. Your app's ID can be found [here](https://developers.facebook.com/apps). The client token can be found under the Security section in Advanced Settings for your app.
 
 ## Running the project
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,10 @@ In order to run the app, you will need to update the code and add your Facebook 
 Update the following file(s):
 - strings.xml
 
-You will need to replace `YOUR_APP_ID` with your app's ID and `YOUR_CLIENT_TOKEN` with your app's client token. Your app's ID can be found [here](https://developers.facebook.com/apps). The client token can be found under the Security section in Advanced Settings for your app.
+You will need to replace `YOUR_APP_ID` with your app's ID and `YOUR_CLIENT_TOKEN` with your app's client token. Your app's ID can be found [here](https://developers.facebook.com/apps). The client token can be found in your app's dashboard by following these steps:
+1. Sign into your developer account.
+2. On the Apps page, select an app to open the dashboard for that app.
+3. On the Dashboard, navigate to Settings > Advanced > Security > Client token.
 
 ## Running the project
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -27,6 +27,7 @@
                 android:resource="@xml/file_paths" />
         </provider>
         <meta-data android:name="com.facebook.sdk.ApplicationId" android:value="@string/facebook_app_id"/>
+        <meta-data android:name="com.facebook.sdk.ClientToken" android:value="@string/facebook_client_token"/>
     </application>
     <queries>
         <provider android:authorities="com.facebook.katana.provider.PlatformProvider" />

--- a/app/src/main/java/com/example/android_share_to_reels/MainActivity.java
+++ b/app/src/main/java/com/example/android_share_to_reels/MainActivity.java
@@ -42,7 +42,7 @@ public class MainActivity extends AppCompatActivity {
         setContentView(R.layout.activity_main);
 
         final Activity activity = this;
-        final String appID = "YOUR_APP_ID";
+        final String appID = getString(R.string.facebook_app_id);
 
         // Get target elements
         videoToShare = findViewById(R.id.videoToShare);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -9,4 +9,5 @@
     <string name="additional_info_title">Sharing to Facebook Reels</string>
     <string name="additional_info_text">Upload a video and choose one of the options to share it on Facebook Reels!</string>
     <string name="facebook_app_id">YOUR_APP_ID</string>
+    <string name="facebook_client_token">YOUR_CLIENT_TOKEN</string>
 </resources>


### PR DESCRIPTION
We can specify the Facebook App ID once in `strings.xml` and reuse it in both `AndroidManifest.xml` and `MainActivity.java`.

In order to use the FacebookSdk, a Facebook client token needs to be specified in `AndroidManifest.xml`.

https://developers.facebook.com/docs/android/getting-started/