### PR TITLE
fix sharing with sample video

### DIFF
--- a/app/src/main/java/com/example/android_share_to_reels/MainActivity.java
+++ b/app/src/main/java/com/example/android_share_to_reels/MainActivity.java
@@ -51,8 +51,8 @@ public class MainActivity extends AppCompatActivity {
         btnShareToReelsWithSticker = findViewById(R.id.btnShareToReelsWithSticker);
 
         // Define initial state
-        changeBtnStatus(btnShareToReels, false);
-        changeBtnStatus(btnShareToReelsWithSticker, false);
+        changeBtnStatus(btnShareToReels, true);
+        changeBtnStatus(btnShareToReelsWithSticker, true);
         loadSampleVideo();
 
         btnLoadVideo.setOnClickListener(view -> {
@@ -141,9 +141,8 @@ public class MainActivity extends AppCompatActivity {
     }
 
     private void loadSampleVideo() {
-        String path = "android.resource://" + getPackageName() + "/" + R.raw.sample_video;
-        Uri sampleVideoUri = Uri.parse(path);
-        loadVideoPreview(sampleVideoUri);
+        targetUri = createExternalURIFromResource(R.raw.sample_video, "sample_video.MOV");
+        loadVideoPreview(targetUri);
     }
 
     private void showFailureMessage(Activity activity) {


### PR DESCRIPTION
In order to share the sample video, we need to use the existing `createExternalURIFromResource` method that we're already using for sharing stickers. Similar to the sample sticker, the sample video is also saved in the raw resources directory. This means that we need to read in the file and use a FileProvider.